### PR TITLE
revert to default CI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ matrix:
 notifications:
   email: false
 
-script: # the default script is equivalent to the following
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --project -e 'using Pkg; Pkg.add([PackageSpec(url="https://github.com/tanmaykm/LogCompose.jl", rev="v0.2.0"),PackageSpec(url="https://github.com/tanmaykm/SyslogLogging.jl.git", rev="v0.1.1")]); Pkg.build(); Pkg.test(; coverage=true)';
+#script: # the default script is equivalent to the following
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia --project -e 'using Pkg; Pkg.build(); Pkg.test(; coverage=true)';
 
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';


### PR DESCRIPTION
now that LogCompose & SyslogLogging are registered, we don't need to do Pkg add of github repo directly